### PR TITLE
Use the queue group name as the durable subscription name

### DIFF
--- a/v4/events/natsjs/nats.go
+++ b/v4/events/natsjs/nats.go
@@ -186,7 +186,7 @@ func (s *stream) Consume(topic string, opts ...events.ConsumeOption) (<-chan eve
 
 	// setup the options
 	subOpts := []nats.SubOpt{
-		nats.Durable(topic),
+		nats.Durable(options.Group),
 	}
 
 	if options.CustomRetries {


### PR DESCRIPTION
Using the topic means that the subscription will wrongly be reused on
subsequent, distinct subscriptions for the same topic.
/cc @wkloucek @xpunch 