### PR TITLE
store: do not list emptystring for prefix mismatches

### DIFF
--- a/v4/store/memory/memory.go
+++ b/v4/store/memory/memory.go
@@ -123,15 +123,13 @@ func (m *memoryStore) delete(prefix, key string) {
 
 func (m *memoryStore) list(prefix string, limit, offset uint) []string {
 	allItems := m.store.Items()
-	allKeys := make([]string, len(allItems))
-	i := 0
+	allKeys := make([]string, 0, len(allItems))
 
 	for k := range allItems {
 		if !strings.HasPrefix(k, prefix+"/") {
 			continue
 		}
-		allKeys[i] = strings.TrimPrefix(k, prefix+"/")
-		i++
+		allKeys = append(allkeys, strings.TrimPrefix(k, prefix+"/"))
 	}
 
 	if limit != 0 || offset != 0 {

--- a/v4/store/memory/memory.go
+++ b/v4/store/memory/memory.go
@@ -129,7 +129,7 @@ func (m *memoryStore) list(prefix string, limit, offset uint) []string {
 		if !strings.HasPrefix(k, prefix+"/") {
 			continue
 		}
-		allKeys = append(allkeys, strings.TrimPrefix(k, prefix+"/"))
+		allKeys = append(allKeys, strings.TrimPrefix(k, prefix+"/"))
 	}
 
 	if limit != 0 || offset != 0 {


### PR DESCRIPTION
When the memory implementation of the store.List() uses a prefix it will now only return the matching entries instead of matching entries mixed with emptystring for mismatches.