### PR TITLE
feat: optimization consul watcher

### DIFF
--- a/v2/registry/consul/watcher.go
+++ b/v2/registry/consul/watcher.go
@@ -40,7 +40,10 @@ func newConsulWatcher(cr *consulRegistry, opts ...registry.WatchOption) (registr
 		services: make(map[string][]*registry.Service),
 	}
 
-	wp, err := watch.Parse(map[string]interface{}{"type": "services"})
+	wp, err := watch.Parse(map[string]interface{}{
+		"service": wo.Service,
+		"type":    "service",
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/v3/registry/consul/watcher.go
+++ b/v3/registry/consul/watcher.go
@@ -38,7 +38,10 @@ func newConsulWatcher(cr *consulRegistry, opts ...registry.WatchOption) (registr
 		services: make(map[string][]*registry.Service),
 	}
 
-	wp, err := watch.Parse(map[string]interface{}{"type": "services"})
+	wp, err := watch.Parse(map[string]interface{}{
+		"service": wo.Service,
+		"type":    "service",
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/v4/registry/consul/watcher.go
+++ b/v4/registry/consul/watcher.go
@@ -39,7 +39,10 @@ func newConsulWatcher(cr *consulRegistry, opts ...registry.WatchOption) (registr
 		services: make(map[string][]*registry.Service),
 	}
 
-	wp, err := watch.Parse(map[string]interface{}{"type": "services"})
+	wp, err := watch.Parse(map[string]interface{}{
+		"service": wo.Service,
+		"type":    "service",
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
before: go-micro service will watch all catalog in consul , it will put a lot of burden on Consul
after: go-micro service only watch that the called service in Consul , 