### PR TITLE
fixed if configure repeat, client resource close

### DIFF
--- a/v4/store/redis/redis.go
+++ b/v4/store/redis/redis.go
@@ -173,6 +173,10 @@ func (r *rkv) configure() error {
 		}
 	}
 
+	if r.Client != nil {
+		r.Client.Close()
+	}
+	
 	r.Client = redis.NewClient(redisOptions)
 
 	return nil


### PR DESCRIPTION
Because Init and New method will call configure, May cause duplicate Client resources to be declared and not released