### PR TITLE
Update consul.go

### DIFF
--- a/v4/store/consul/consul.go
+++ b/v4/store/consul/consul.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"go-micro.dev/v4/store"
@@ -79,7 +79,7 @@ func (c *ckv) Write(record *store.Record, opts ...store.WriteOption) error {
 	}
 
 	_, err := c.client.KV().Put(&api.KVPair{
-		Key:   filepath.Join(options.Table, record.Key),
+		Key:   strings.Join([]string{options.Table, record.Key},"/"),
 		Value: record.Value,
 	}, nil)
 	return err


### PR DESCRIPTION
there are a different string when using filepath.Join() in windows and  linux. in windows "xxx\xxx\xxx", linux "xxx/xxx/xxx". consul create dir when key like "xxx/xxx/xxx" but other are not.