### PR TITLE
feat(events/redis): Allow redis:// address in events

### DIFF
--- a/v4/events/redis/options.go
+++ b/v4/events/redis/options.go
@@ -13,6 +13,11 @@ type Options struct {
 // Option is a function which configures options
 type Option func(o *Options)
 
+// Address sets the Redis address option.
+// Needs to be a full URL with scheme (redis://, rediss://, unix://).
+// (eg. redis://user:password@localhost:6789/3?dial_timeout=3).
+// Alternatively, the address can simply be the `host:port` format
+// where User, Password, TLSConfig are defined with their respective options.
 func Address(addr string) Option {
 	return func(o *Options) {
 		o.Address = addr

--- a/v4/events/redis/redis.go
+++ b/v4/events/redis/redis.go
@@ -34,16 +34,23 @@ type redisStream struct {
 }
 
 func NewStream(opts ...Option) (events.Stream, error) {
-	options := Options{}
+	options := Options{
+		Address: "redis://127.0.0.1:6379",
+	}
 	for _, o := range opts {
 		o(&options)
 	}
-	rc := redis.NewClient(&redis.Options{
-		Addr:      options.Address,
-		Username:  options.User,
-		Password:  options.Password,
-		TLSConfig: options.TLSConfig,
-	})
+	redisOptions, err := redis.ParseURL(options.Address)
+	if err != nil {
+		redisOptions = &redis.Options{
+			Addr:      options.Address,
+			Username:  options.User,
+			Password:  options.Password,
+			TLSConfig: options.TLSConfig,
+		}
+	}
+
+	rc := redis.NewClient(redisOptions)
 	rs := &redisStream{
 		redisClient: rc,
 		attempts:    map[string]int{},


### PR DESCRIPTION
Allows the user to pass client options (eg. `?dial_timeout=3`)

It aligns the behavior with other redis plugins (cache, store, broker)

The previous format is still accepted