### PR TITLE
feat(broker/rabbitmq): Redact creds in Address()

### DIFF
--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -310,12 +310,12 @@ func (r *rbroker) String() string {
 
 func (r *rbroker) Address() string {
 	if len(r.addrs) > 0 {
-		url, err := url.Parse(r.addrs[0])
+		u, err := url.Parse(r.addrs[0])
 		if err != nil {
 			return ""
 		}
 
-		return url.Redacted()
+		return u.Redacted()
 	}
 	return ""
 }

--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -4,6 +4,7 @@ package rabbitmq
 import (
 	"context"
 	"errors"
+	"net/url"
 	"sync"
 	"time"
 
@@ -309,7 +310,12 @@ func (r *rbroker) String() string {
 
 func (r *rbroker) Address() string {
 	if len(r.addrs) > 0 {
-		return r.addrs[0]
+		url, err := url.Parse(r.addrs[0])
+		if err != nil {
+			return ""
+		}
+
+		return url.Redacted()
 	}
 	return ""
 }


### PR DESCRIPTION
As the way credentials are passed to RabbitMQ is through the address, this ensures that `Address()` returns a redacted URL to prevent username/password from being shown in logs.

Closes #42 