### PR TITLE
fix(broker/rabbitmq): Wait for handler upon unsub if autoack disabled

### DIFF
--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/streadway/amqp"
 	"go-micro.dev/v4/broker"
-	"go-micro.dev/v4/logger"
 	"go-micro.dev/v4/util/cmd"
 )
 
@@ -152,7 +151,6 @@ func (s *subscriber) resubscribe() {
 				return
 			case d, ok := <-sub:
 				if !ok {
-					logger.Info("breaking loop")
 					break SubLoop
 				}
 				s.r.wg.Add(1)

--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -74,7 +74,13 @@ func (s *subscriber) Topic() string {
 func (s *subscriber) Unsubscribe() error {
 
 	s.unsub <- true
-	s.wg.Wait()
+
+	// Need to wait on subscriber to exit if autoack is disabled
+	// since closing the channel will prevent the ack/nack from
+	// being sent upon handler completion.
+	if !s.opts.AutoAck {
+		s.wg.Wait()
+	}
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()


### PR DESCRIPTION
Closing the RabbitMQ channel upon unsubscribe prevents any in-flight messages from sending an ack/nack if autoack is disabled.

This change instead waits for the subscription to exit if autoack is disabled to allow any in-flight handlers to complete, thus marking the message appropriately.
