### PR TITLE
list metadata value in consul's meta page

### DIFF
--- a/v4/registry/consul/consul.go
+++ b/v4/registry/consul/consul.go
@@ -268,6 +268,7 @@ func (c *consulRegistry) Register(s *registry.Service, opts ...registry.Register
 		Tags:    tags,
 		Port:    port,
 		Address: host,
+		Meta:    node.Metadata,
 		Check:   check,
 	}
 


### PR DESCRIPTION
Assign node.Metadata to consul agent's Meta when registering services.

![image](https://user-images.githubusercontent.com/519830/184095739-04ff4421-07d3-4dda-9976-29ec810fcb77.png)
