### PR TITLE
fix(broker/rabbitmq): header conversion for non-string types

### DIFF
--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -4,6 +4,7 @@ package rabbitmq
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"sync"
 	"time"
@@ -290,7 +291,7 @@ func (r *rbroker) Subscribe(topic string, handler broker.Handler, opts ...broker
 	fn := func(msg amqp.Delivery) {
 		header := make(map[string]string)
 		for k, v := range msg.Headers {
-			header[k], _ = v.(string)
+			header[k] = fmt.Sprintf("%v", v)
 		}
 
 		// Get rid of dependence on 'Micro-Topic'


### PR DESCRIPTION
RabbitMQ allows various types of values in message headers, such as string, int, float, time, etc.

Currently, if a RabbitMQ header value in a message is not a string, then the conversion to the go-micro `map[string]string`  based headers results in `""` being set for non-string values, due to direct casting.

This change instead attempts to convert the value via `fmt.Sprintf` instead, which should allow at least basic (non-nested) types to be set correctly, such as `x-delivery-count` set by [quorum queues for poison message handling](https://www.rabbitmq.com/quorum-queues.html#poison-message-handling).