### PR TITLE
fix(sync/etcd): close lock session to prevent lease leak

### DIFF
--- a/v4/sync/etcd/etcd.go
+++ b/v4/sync/etcd/etcd.go
@@ -143,9 +143,13 @@ func (e *etcdSync) Unlock(id string) error {
 	if !ok {
 		return errors.New("lock not found")
 	}
-	err := v.m.Unlock(context.Background())
-	delete(e.locks, id)
-	return err
+
+	if err := v.m.Unlock(context.Background()); err != nil {
+		return err
+	}
+
+	defer delete(e.locks, id)
+	return v.s.Close()
 }
 
 func (e *etcdSync) String() string {


### PR DESCRIPTION
The call to `NewSession()` when creating a lock triggers a continuous keep-alive go routine that will remain running until the session is explicitly closed.

So, if `Lock()` and `Unlock()` are called repeatedly, this results in a leak of both go routines on the service-side and leases on the etcd-side, until the service is restarted.

This change closes the underlying session if the lock is successfully closed, to prevent said leak. Similar change might need to be made on the `Leader()` and `Resign()` functions.