### PR TITLE
fix(server/http): passthrough subscriber ctx

### DIFF
--- a/v4/server/http/http.go
+++ b/v4/server/http/http.go
@@ -188,6 +188,10 @@ func (h *httpServer) Register() error {
 			subOpts = append(subOpts, broker.Queue(queue))
 		}
 
+		if cx := sb.Options().Context; cx != nil {
+			subOpts = append(subOpts, broker.SubscribeContext(cx))
+		}
+
 		if !sb.Options().AutoAck {
 			subOpts = append(subOpts, broker.DisableAutoAck())
 		}


### PR DESCRIPTION
Unlike grpc server, the http server does not passthrough the given subscriber context to the broker, which means certain broker plug-in specific configuration options could be missed when subscribing.

This change fixes the behavior to be consistent with grpc server.