### PR TITLE
feat(broker/rabbitmq): add ConfirmPublish option and logic

### DIFF
--- a/v4/broker/rabbitmq/connection_test.go
+++ b/v4/broker/rabbitmq/connection_test.go
@@ -78,13 +78,13 @@ func TestTryToConnectTLS(t *testing.T) {
 	}
 }
 
-func TestNewRabbitMQPrefetchConfirm(t *testing.T) {
+func TestNewRabbitMQPrefetchConfirmPublish(t *testing.T) {
 	testcases := []struct {
 		title          string
 		urls           []string
 		prefetchCount  int
 		prefetchGlobal bool
-		confirm        bool
+		confirmPublish bool
 	}{
 		{"Multiple URLs", []string{"amqp://example.com/one", "amqp://example.com/two"}, 1, true, true},
 		{"Insecure URL", []string{"amqp://example.com"}, 1, true, true},
@@ -94,7 +94,7 @@ func TestNewRabbitMQPrefetchConfirm(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn(Exchange{Name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal, test.confirm)
+		conn := newRabbitMQConn(Exchange{Name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal, test.confirmPublish)
 
 		if have, want := conn.prefetchCount, test.prefetchCount; have != want {
 			t.Errorf("%s: invalid prefetch count, want %d, have %d", test.title, want, have)
@@ -104,7 +104,7 @@ func TestNewRabbitMQPrefetchConfirm(t *testing.T) {
 			t.Errorf("%s: invalid prefetch global setting, want %t, have %t", test.title, want, have)
 		}
 
-		if have, want := conn.confirm, test.confirm; have != want {
+		if have, want := conn.confirmPublish, test.confirmPublish; have != want {
 			t.Errorf("%s: invalid confirm setting, want %t, have %t", test.title, want, have)
 		}
 	}

--- a/v4/broker/rabbitmq/connection_test.go
+++ b/v4/broker/rabbitmq/connection_test.go
@@ -22,7 +22,7 @@ func TestNewRabbitMQConnURL(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn(Exchange{Name: "exchange"}, test.urls, 0, false)
+		conn := newRabbitMQConn(Exchange{Name: "exchange"}, test.urls, 0, false, false)
 
 		if have, want := conn.url, test.want; have != want {
 			t.Errorf("%s: invalid url, want %q, have %q", test.title, want, have)
@@ -64,7 +64,7 @@ func TestTryToConnectTLS(t *testing.T) {
 	for _, test := range testcases {
 		dialCount, dialTLSCount = 0, 0
 
-		conn := newRabbitMQConn(Exchange{Name: "exchange"}, []string{test.url}, 0, false)
+		conn := newRabbitMQConn(Exchange{Name: "exchange"}, []string{test.url}, 0, false, false)
 		conn.tryConnect(test.secure, test.amqpConfig)
 
 		have := dialCount
@@ -78,22 +78,23 @@ func TestTryToConnectTLS(t *testing.T) {
 	}
 }
 
-func TestNewRabbitMQPrefetch(t *testing.T) {
+func TestNewRabbitMQPrefetchConfirm(t *testing.T) {
 	testcases := []struct {
 		title          string
 		urls           []string
 		prefetchCount  int
 		prefetchGlobal bool
+		confirm        bool
 	}{
-		{"Multiple URLs", []string{"amqp://example.com/one", "amqp://example.com/two"}, 1, true},
-		{"Insecure URL", []string{"amqp://example.com"}, 1, true},
-		{"Secure URL", []string{"amqps://example.com"}, 1, true},
-		{"Invalid URL", []string{"http://example.com"}, 1, true},
-		{"No URLs", []string{}, 1, true},
+		{"Multiple URLs", []string{"amqp://example.com/one", "amqp://example.com/two"}, 1, true, true},
+		{"Insecure URL", []string{"amqp://example.com"}, 1, true, true},
+		{"Secure URL", []string{"amqps://example.com"}, 1, true, true},
+		{"Invalid URL", []string{"http://example.com"}, 1, true, true},
+		{"No URLs", []string{}, 1, true, true},
 	}
 
 	for _, test := range testcases {
-		conn := newRabbitMQConn(Exchange{Name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal)
+		conn := newRabbitMQConn(Exchange{Name: "exchange"}, test.urls, test.prefetchCount, test.prefetchGlobal, test.confirm)
 
 		if have, want := conn.prefetchCount, test.prefetchCount; have != want {
 			t.Errorf("%s: invalid prefetch count, want %d, have %d", test.title, want, have)
@@ -101,6 +102,10 @@ func TestNewRabbitMQPrefetch(t *testing.T) {
 
 		if have, want := conn.prefetchGlobal, test.prefetchGlobal; have != want {
 			t.Errorf("%s: invalid prefetch global setting, want %t, have %t", test.title, want, have)
+		}
+
+		if have, want := conn.confirm, test.confirm; have != want {
+			t.Errorf("%s: invalid confirm setting, want %t, have %t", test.title, want, have)
 		}
 	}
 }

--- a/v4/broker/rabbitmq/options.go
+++ b/v4/broker/rabbitmq/options.go
@@ -12,7 +12,7 @@ type headersKey struct{}
 type queueArgumentsKey struct{}
 type prefetchCountKey struct{}
 type prefetchGlobalKey struct{}
-type confirmKey struct{}
+type confirmPublishKey struct{}
 type exchangeKey struct{}
 type requeueOnErrorKey struct{}
 type deliveryMode struct{}
@@ -70,9 +70,9 @@ func PrefetchGlobal() broker.Option {
 	return setBrokerOption(prefetchGlobalKey{}, true)
 }
 
-// Confirm ensures all published messages are confirmed by waiting for an ack/nack from the broker
-func Confirm() broker.Option {
-	return setBrokerOption(confirmKey{}, true)
+// ConfirmPublish ensures all published messages are confirmed by waiting for an ack/nack from the broker
+func ConfirmPublish() broker.Option {
+	return setBrokerOption(confirmPublishKey{}, true)
 }
 
 // DeliveryMode sets a delivery mode for publishing

--- a/v4/broker/rabbitmq/options.go
+++ b/v4/broker/rabbitmq/options.go
@@ -12,6 +12,7 @@ type headersKey struct{}
 type queueArgumentsKey struct{}
 type prefetchCountKey struct{}
 type prefetchGlobalKey struct{}
+type confirmKey struct{}
 type exchangeKey struct{}
 type requeueOnErrorKey struct{}
 type deliveryMode struct{}
@@ -67,6 +68,11 @@ func PrefetchCount(c int) broker.Option {
 // PrefetchGlobal creates a durable queue when subscribing.
 func PrefetchGlobal() broker.Option {
 	return setBrokerOption(prefetchGlobalKey{}, true)
+}
+
+// Confirm ensures all published messages are confirmed by waiting for an ack/nack from the broker
+func Confirm() broker.Option {
+	return setBrokerOption(confirmKey{}, true)
 }
 
 // DeliveryMode sets a delivery mode for publishing

--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -352,7 +352,7 @@ func (r *rbroker) Init(opts ...broker.Option) error {
 
 func (r *rbroker) Connect() error {
 	if r.conn == nil {
-		r.conn = newRabbitMQConn(r.getExchange(), r.opts.Addrs, r.getPrefetchCount(), r.getPrefetchGlobal(), r.getConfirm())
+		r.conn = newRabbitMQConn(r.getExchange(), r.opts.Addrs, r.getPrefetchCount(), r.getPrefetchGlobal(), r.getConfirmPublish())
 	}
 
 	conf := defaultAmqpConfig
@@ -419,9 +419,9 @@ func (r *rbroker) getPrefetchGlobal() bool {
 	return DefaultPrefetchGlobal
 }
 
-func (r *rbroker) getConfirm() bool {
-	if e, ok := r.opts.Context.Value(confirmKey{}).(bool); ok {
+func (r *rbroker) getConfirmPublish() bool {
+	if e, ok := r.opts.Context.Value(confirmPublishKey{}).(bool); ok {
 		return e
 	}
-	return DefaultConfirm
+	return DefaultConfirmPublish
 }

--- a/v4/broker/rabbitmq/rabbitmq.go
+++ b/v4/broker/rabbitmq/rabbitmq.go
@@ -352,7 +352,7 @@ func (r *rbroker) Init(opts ...broker.Option) error {
 
 func (r *rbroker) Connect() error {
 	if r.conn == nil {
-		r.conn = newRabbitMQConn(r.getExchange(), r.opts.Addrs, r.getPrefetchCount(), r.getPrefetchGlobal())
+		r.conn = newRabbitMQConn(r.getExchange(), r.opts.Addrs, r.getPrefetchCount(), r.getPrefetchGlobal(), r.getConfirm())
 	}
 
 	conf := defaultAmqpConfig
@@ -417,4 +417,11 @@ func (r *rbroker) getPrefetchGlobal() bool {
 		return e
 	}
 	return DefaultPrefetchGlobal
+}
+
+func (r *rbroker) getConfirm() bool {
+	if e, ok := r.opts.Context.Value(confirmKey{}).(bool); ok {
+		return e
+	}
+	return DefaultConfirm
 }


### PR DESCRIPTION
Currently, the RabbitMQ broker plugin does not allow for making sure that published messages are confirmed by the broker, meaning that messages could be lost in case the broker is blocking publishings (such as under high memory pressure).

Since confirmations are generally much slower, we add an option to enable them for the broker via `ConfirmPublish`, which by default is false.