### PR TITLE
feat(cache;store;events/redis): Add cluster and sentinel failover support

### DIFF
--- a/v4/cache/redis/options.go
+++ b/v4/cache/redis/options.go
@@ -1,0 +1,48 @@
+package redis
+
+import (
+	"context"
+
+	"github.com/go-redis/redis/v8"
+	"go-micro.dev/v4/cache"
+)
+
+type redisOptionsContextKey struct{}
+
+// WithRedisOptions sets advanced options for redis.
+func WithRedisOptions(options redis.UniversalOptions) cache.Option {
+	return func(o *cache.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+
+		o.Context = context.WithValue(o.Context, redisOptionsContextKey{}, options)
+	}
+}
+
+func newUniversalClient(options cache.Options) redis.UniversalClient {
+	if options.Context == nil {
+		options.Context = context.Background()
+	}
+
+	opts, ok := options.Context.Value(redisOptionsContextKey{}).(redis.UniversalOptions)
+	if !ok {
+		addr := "redis://127.0.0.1:6379"
+		if len(options.Address) > 0 {
+			addr = options.Address
+		}
+
+		redisOptions, err := redis.ParseURL(addr)
+		if err != nil {
+			redisOptions = &redis.Options{Addr: addr}
+		}
+
+		return redis.NewClient(redisOptions)
+	}
+
+	if len(opts.Addrs) == 0 && len(options.Address) > 0 {
+		opts.Addrs = []string{options.Address}
+	}
+
+	return redis.NewUniversalClient(&opts)
+}

--- a/v4/cache/redis/options_test.go
+++ b/v4/cache/redis/options_test.go
@@ -1,0 +1,139 @@
+package redis
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+	"go-micro.dev/v4/cache"
+)
+
+func Test_newUniversalClient(t *testing.T) {
+	type fields struct {
+		options cache.Options
+	}
+	type wantValues struct {
+		username string
+		password string
+		address  string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   wantValues
+	}{
+		{name: "No Url", fields: fields{options: cache.Options{}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "127.0.0.1:6379",
+			}},
+		{name: "legacy Url", fields: fields{options: cache.Options{Address: "127.0.0.1:6379"}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "127.0.0.1:6379",
+			}},
+		{name: "New Url", fields: fields{options: cache.Options{Address: "redis://127.0.0.1:6379"}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "127.0.0.1:6379",
+			}},
+		{name: "Url with Pwd", fields: fields{options: cache.Options{Address: "redis://:password@redis:6379"}},
+			want: wantValues{
+				username: "",
+				password: "password",
+				address:  "redis:6379",
+			}},
+		{name: "Url with username and Pwd", fields: fields{
+			options: cache.Options{Address: "redis://username:password@redis:6379"}},
+			want: wantValues{
+				username: "username",
+				password: "password",
+				address:  "redis:6379",
+			}},
+
+		{name: "Sentinel Failover client", fields: fields{
+			options: cache.Options{
+				Context: context.WithValue(
+					context.TODO(), redisOptionsContextKey{},
+					redis.UniversalOptions{MasterName: "master-name"}),
+			}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "FailoverClient", // <- Placeholder set by NewFailoverClient
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			univClient := newUniversalClient(tt.fields.options)
+			client, ok := univClient.(*redis.Client)
+			if !ok {
+				t.Errorf("newUniversalClient() expect a *redis.Client")
+				return
+			}
+			if client.Options().Addr != tt.want.address {
+				t.Errorf("newUniversalClient() Address = %v, want address %v", client.Options().Addr, tt.want.address)
+			}
+			if client.Options().Password != tt.want.password {
+				t.Errorf("newUniversalClient() password = %v, want password %v", client.Options().Password, tt.want.password)
+			}
+			if client.Options().Username != tt.want.username {
+				t.Errorf("newUniversalClient() username = %v, want username %v", client.Options().Username, tt.want.username)
+			}
+		})
+	}
+}
+
+func Test_newUniversalClientCluster(t *testing.T) {
+	type fields struct {
+		options cache.Options
+	}
+	type wantValues struct {
+		username string
+		password string
+		addrs    []string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   wantValues
+	}{
+		{name: "Addrs in redis options", fields: fields{
+			options: cache.Options{
+				Address: "127.0.0.1:6379", // <- ignored
+				Context: context.WithValue(
+					context.TODO(), redisOptionsContextKey{},
+					redis.UniversalOptions{Addrs: []string{"127.0.0.1:6381", "127.0.0.1:6382"}}),
+			}},
+			want: wantValues{
+				username: "",
+				password: "",
+				addrs:    []string{"127.0.0.1:6381", "127.0.0.1:6382"},
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			univClient := newUniversalClient(tt.fields.options)
+			client, ok := univClient.(*redis.ClusterClient)
+			if !ok {
+				t.Errorf("newUniversalClient() expect a *redis.ClusterClient")
+				return
+			}
+			if !reflect.DeepEqual(client.Options().Addrs, tt.want.addrs) {
+				t.Errorf("newUniversalClient() Addrs = %v, want addrs %v", client.Options().Addrs, tt.want.addrs)
+			}
+			if client.Options().Password != tt.want.password {
+				t.Errorf("newUniversalClient() password = %v, want password %v", client.Options().Password, tt.want.password)
+			}
+			if client.Options().Username != tt.want.username {
+				t.Errorf("newUniversalClient() username = %v, want username %v", client.Options().Username, tt.want.username)
+			}
+		})
+	}
+}

--- a/v4/cache/redis/redis.go
+++ b/v4/cache/redis/redis.go
@@ -16,27 +16,15 @@ func init() {
 // NewCache returns a new redis cache.
 func NewCache(opts ...cache.Option) cache.Cache {
 	options := cache.NewOptions(opts...)
-	addr := "redis://127.0.0.1:6379"
-	if len(options.Address) > 0 {
-		addr = options.Address
-	}
-	redisOptions, err := redis.ParseURL(addr)
-	if err != nil {
-		redisOptions = &redis.Options{
-			Addr:     addr,
-			Password: "",
-			DB:       0,
-		}
-	}
 	return &redisCache{
 		opts:   options,
-		client: redis.NewClient(redisOptions),
+		client: newUniversalClient(options),
 	}
 }
 
 type redisCache struct {
 	opts   cache.Options
-	client *redis.Client
+	client redis.UniversalClient
 }
 
 func (c *redisCache) Get(ctx context.Context, key string) (interface{}, time.Time, error) {

--- a/v4/events/redis/options_test.go
+++ b/v4/events/redis/options_test.go
@@ -1,0 +1,132 @@
+package stream
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func Test_newUniversalClient(t *testing.T) {
+	type fields struct {
+		options Options
+	}
+	type wantValues struct {
+		username string
+		password string
+		address  string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   wantValues
+	}{
+		{name: "No Url", fields: fields{options: Options{}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "127.0.0.1:6379",
+			}},
+		{name: "legacy Url", fields: fields{options: Options{Address: "127.0.0.1:6379"}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "127.0.0.1:6379",
+			}},
+		{name: "New Url", fields: fields{options: Options{Address: "redis://127.0.0.1:6379"}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "127.0.0.1:6379",
+			}},
+		{name: "Url with Pwd", fields: fields{options: Options{Address: "redis://:password@redis:6379"}},
+			want: wantValues{
+				username: "",
+				password: "password",
+				address:  "redis:6379",
+			}},
+		{name: "Url with username and Pwd", fields: fields{options: Options{Address: "redis://username:password@redis:6379"}},
+			want: wantValues{
+				username: "username",
+				password: "password",
+				address:  "redis:6379",
+			}},
+
+		{name: "Sentinel Failover client", fields: fields{
+			options: Options{
+				RedisOptions: &redis.UniversalOptions{MasterName: "master-name"},
+			}},
+			want: wantValues{
+				username: "",
+				password: "",
+				address:  "FailoverClient", // <- Placeholder set by NewFailoverClient
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			univClient := tt.fields.options.newUniversalClient()
+			client, ok := univClient.(*redis.Client)
+			if !ok {
+				t.Errorf("newUniversalClient() expect a *redis.Client")
+				return
+			}
+			if client.Options().Addr != tt.want.address {
+				t.Errorf("newUniversalClient() Address = %v, want address %v", client.Options().Addr, tt.want.address)
+			}
+			if client.Options().Password != tt.want.password {
+				t.Errorf("newUniversalClient() password = %v, want password %v", client.Options().Password, tt.want.password)
+			}
+			if client.Options().Username != tt.want.username {
+				t.Errorf("newUniversalClient() username = %v, want username %v", client.Options().Username, tt.want.username)
+			}
+		})
+	}
+}
+
+func Test_newUniversalClientCluster(t *testing.T) {
+	type fields struct {
+		options Options
+	}
+	type wantValues struct {
+		username string
+		password string
+		addrs    []string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   wantValues
+	}{
+		{name: "Addrs in redis options", fields: fields{
+			options: Options{
+				Address:      "127.0.0.1:6379", // <- ignored
+				RedisOptions: &redis.UniversalOptions{Addrs: []string{"127.0.0.1:6381", "127.0.0.1:6382"}},
+			}},
+			want: wantValues{
+				username: "",
+				password: "",
+				addrs:    []string{"127.0.0.1:6381", "127.0.0.1:6382"},
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			univClient := tt.fields.options.newUniversalClient()
+			client, ok := univClient.(*redis.ClusterClient)
+			if !ok {
+				t.Errorf("newUniversalClient() expect a *redis.ClusterClient")
+				return
+			}
+			if !reflect.DeepEqual(client.Options().Addrs, tt.want.addrs) {
+				t.Errorf("newUniversalClient() Addrs = %v, want addrs %v", client.Options().Addrs, tt.want.addrs)
+			}
+			if client.Options().Password != tt.want.password {
+				t.Errorf("newUniversalClient() password = %v, want password %v", client.Options().Password, tt.want.password)
+			}
+			if client.Options().Username != tt.want.username {
+				t.Errorf("newUniversalClient() username = %v, want username %v", client.Options().Username, tt.want.username)
+			}
+		})
+	}
+}

--- a/v4/events/redis/redis.go
+++ b/v4/events/redis/redis.go
@@ -29,28 +29,17 @@ const (
 
 type redisStream struct {
 	sync.RWMutex
-	redisClient *redis.Client
+	redisClient redis.UniversalClient
 	attempts    map[string]int
 }
 
 func NewStream(opts ...Option) (events.Stream, error) {
-	options := Options{
-		Address: "redis://127.0.0.1:6379",
-	}
+	options := Options{}
 	for _, o := range opts {
 		o(&options)
 	}
-	redisOptions, err := redis.ParseURL(options.Address)
-	if err != nil {
-		redisOptions = &redis.Options{
-			Addr:      options.Address,
-			Username:  options.User,
-			Password:  options.Password,
-			TLSConfig: options.TLSConfig,
-		}
-	}
 
-	rc := redis.NewClient(redisOptions)
+	rc := options.newUniversalClient()
 	rs := &redisStream{
 		redisClient: rc,
 		attempts:    map[string]int{},

--- a/v4/store/redis/options.go
+++ b/v4/store/redis/options.go
@@ -1,0 +1,48 @@
+package redis
+
+import (
+	"context"
+
+	"github.com/go-redis/redis/v8"
+	"go-micro.dev/v4/store"
+)
+
+type redisOptionsContextKey struct{}
+
+// WithRedisOptions sets advanced options for redis.
+func WithRedisOptions(options redis.UniversalOptions) store.Option {
+	return func(o *store.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+
+		o.Context = context.WithValue(o.Context, redisOptionsContextKey{}, options)
+	}
+}
+
+func newUniversalClient(o store.Options) redis.UniversalClient {
+	if o.Context == nil {
+		o.Context = context.Background()
+	}
+
+	opts, ok := o.Context.Value(redisOptionsContextKey{}).(redis.UniversalOptions)
+	if !ok && len(o.Nodes) <= 1 {
+		addr := "redis://127.0.0.1:6379"
+		if len(o.Nodes) > 0 {
+			addr = o.Nodes[0]
+		}
+
+		redisOptions, err := redis.ParseURL(addr)
+		if err != nil {
+			redisOptions = &redis.Options{Addr: addr}
+		}
+
+		return redis.NewClient(redisOptions)
+	}
+
+	if len(opts.Addrs) == 0 && len(o.Nodes) > 0 {
+		opts.Addrs = o.Nodes
+	}
+
+	return redis.NewUniversalClient(&opts)
+}

--- a/v4/store/redis/redis.go
+++ b/v4/store/redis/redis.go
@@ -13,7 +13,7 @@ import (
 type rkv struct {
 	ctx     context.Context
 	options store.Options
-	Client  *redis.Client
+	Client  redis.UniversalClient
 }
 
 func init() {
@@ -155,27 +155,10 @@ func NewStore(opts ...store.Option) store.Store {
 }
 
 func (r *rkv) configure() error {
-	var redisOptions *redis.Options
-	nodes := r.options.Nodes
-
-	if len(nodes) == 0 {
-		nodes = []string{"redis://127.0.0.1:6379"}
-	}
-
-	redisOptions, err := redis.ParseURL(nodes[0])
-	if err != nil {
-		// Backwards compatibility
-		redisOptions = &redis.Options{
-			Addr:     nodes[0],
-			Password: "", // no password set
-			DB:       0,  // use default DB
-		}
-	}
-
 	if r.Client != nil {
 		r.Client.Close()
 	}
-	r.Client = redis.NewClient(redisOptions)
+	r.Client = newUniversalClient(r.options)
 
 	return nil
 }

--- a/v4/store/redis/redis_test.go
+++ b/v4/store/redis/redis_test.go
@@ -1,7 +1,9 @@
 package redis
 
 import (
+	"context"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,7 +14,6 @@ import (
 func Test_rkv_configure(t *testing.T) {
 	type fields struct {
 		options store.Options
-		Client  *redis.Client
 	}
 	type wantValues struct {
 		username string
@@ -26,56 +27,149 @@ func Test_rkv_configure(t *testing.T) {
 		wantErr bool
 		want    wantValues
 	}{
-		{name: "No Url", fields: fields{options: store.Options{}, Client: nil},
+		{name: "No Url", fields: fields{options: store.Options{}},
 			wantErr: false, want: wantValues{
 				username: "",
 				password: "",
 				address:  "127.0.0.1:6379",
 			}},
-		{name: "legacy Url", fields: fields{options: store.Options{Nodes: []string{"127.0.0.1:6379"}}, Client: nil},
+		{name: "legacy Url", fields: fields{options: store.Options{Nodes: []string{"127.0.0.1:6379"}}},
 			wantErr: false, want: wantValues{
 				username: "",
 				password: "",
 				address:  "127.0.0.1:6379",
 			}},
-		{name: "New Url", fields: fields{options: store.Options{Nodes: []string{"redis://127.0.0.1:6379"}}, Client: nil},
+		{name: "New Url", fields: fields{options: store.Options{Nodes: []string{"redis://127.0.0.1:6379"}}},
 			wantErr: false, want: wantValues{
 				username: "",
 				password: "",
 				address:  "127.0.0.1:6379",
 			}},
-		{name: "Url with Pwd", fields: fields{options: store.Options{Nodes: []string{"redis://:password@redis:6379"}}, Client: nil},
+		{name: "Url with Pwd", fields: fields{options: store.Options{Nodes: []string{"redis://:password@redis:6379"}}},
 			wantErr: false, want: wantValues{
 				username: "",
 				password: "password",
 				address:  "redis:6379",
 			}},
-		{name: "Url with username and Pwd", fields: fields{options: store.Options{Nodes: []string{"redis://username:password@redis:6379"}}, Client: nil},
+		{name: "Url with username and Pwd", fields: fields{
+			options: store.Options{Nodes: []string{"redis://username:password@redis:6379"}}},
 			wantErr: false, want: wantValues{
 				username: "username",
 				password: "password",
 				address:  "redis:6379",
+			}},
+
+		{name: "Sentinel Failover client", fields: fields{
+			options: store.Options{
+				Nodes: []string{"127.0.0.1:6379", "127.0.0.1:6380"},
+				Context: context.WithValue(
+					context.TODO(), redisOptionsContextKey{},
+					redis.UniversalOptions{MasterName: "master-name"}),
+			}},
+			wantErr: false, want: wantValues{
+				username: "",
+				password: "",
+				address:  "FailoverClient", // <- Placeholder set by NewFailoverClient
 			}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &rkv{
 				options: tt.fields.options,
-				Client:  tt.fields.Client,
 			}
 			err := r.configure()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("configure() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if r.Client.Options().Addr != tt.want.address {
-				t.Errorf("configure() Address = %v, want address %v", r.Client.Options().Addr, tt.want.address)
+			client, ok := r.Client.(*redis.Client)
+			if !ok {
+				t.Errorf("configure() expect a *redis.Client")
+				return
 			}
-			if r.Client.Options().Password != tt.want.password {
-				t.Errorf("configure() password = %v, want password %v", r.Client.Options().Password, tt.want.password)
+			if client.Options().Addr != tt.want.address {
+				t.Errorf("configure() Address = %v, want address %v", client.Options().Addr, tt.want.address)
 			}
-			if r.Client.Options().Username != tt.want.username {
-				t.Errorf("configure() username = %v, want username %v", r.Client.Options().Username, tt.want.username)
+			if client.Options().Password != tt.want.password {
+				t.Errorf("configure() password = %v, want password %v", client.Options().Password, tt.want.password)
+			}
+			if client.Options().Username != tt.want.username {
+				t.Errorf("configure() username = %v, want username %v", client.Options().Username, tt.want.username)
+			}
+		})
+	}
+}
+
+func Test_rkv_configure_cluster(t *testing.T) {
+	type fields struct {
+		options store.Options
+	}
+	type wantValues struct {
+		username string
+		password string
+		addrs    []string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+		want    wantValues
+	}{
+		{name: "Nodes", fields: fields{options: store.Options{Nodes: []string{"127.0.0.1:6379", "127.0.0.1:6380"}}},
+			wantErr: false, want: wantValues{
+				username: "",
+				password: "",
+				addrs:    []string{"127.0.0.1:6379", "127.0.0.1:6380"},
+			}},
+		{name: "Nodes with redis options", fields: fields{
+			options: store.Options{
+				Nodes: []string{"127.0.0.1:6379", "127.0.0.1:6380"},
+				Context: context.WithValue(
+					context.TODO(), redisOptionsContextKey{},
+					redis.UniversalOptions{}),
+			}},
+			wantErr: false, want: wantValues{
+				username: "",
+				password: "",
+				addrs:    []string{"127.0.0.1:6379", "127.0.0.1:6380"},
+			}},
+		{name: "Nodes in redis options", fields: fields{
+			options: store.Options{
+				Nodes: []string{"127.0.0.1:6379", "127.0.0.1:6380"}, // <- ignored
+				Context: context.WithValue(
+					context.TODO(), redisOptionsContextKey{},
+					redis.UniversalOptions{Addrs: []string{"127.0.0.1:6381", "127.0.0.1:6382"}}),
+			}},
+			wantErr: false, want: wantValues{
+				username: "",
+				password: "",
+				addrs:    []string{"127.0.0.1:6381", "127.0.0.1:6382"},
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &rkv{
+				options: tt.fields.options,
+			}
+			err := r.configure()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("configure() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			client, ok := r.Client.(*redis.ClusterClient)
+			if !ok {
+				t.Errorf("configure() expect a *redis.ClusterClient")
+				return
+			}
+			if !reflect.DeepEqual(client.Options().Addrs, tt.want.addrs) {
+				t.Errorf("configure() Addrs = %v, want addrs %v", client.Options().Addrs, tt.want.addrs)
+			}
+			if client.Options().Password != tt.want.password {
+				t.Errorf("configure() password = %v, want password %v", client.Options().Password, tt.want.password)
+			}
+			if client.Options().Username != tt.want.username {
+				t.Errorf("configure() username = %v, want username %v", client.Options().Username, tt.want.username)
 			}
 		})
 	}


### PR DESCRIPTION
Add `WithRedisOptions` option that accept a `redis.UniversalOptions` struct :

1. If the MasterName option is specified, a sentinel-backed FailoverClient is returned.
2. if the number of Addrs is two or more, a ClusterClient is returned.
3. Otherwise, a single-node Client is returned.