### PR TITLE
server/grpc: initiate wg on configure call instead of constructor

### DIFF
--- a/v3/server/grpc/grpc.go
+++ b/v3/server/grpc/grpc.go
@@ -88,7 +88,6 @@ func newGRPCServer(opts ...server.Option) server.Server {
 		handlers:    make(map[string]server.Handler),
 		subscribers: make(map[*subscriber][]broker.Subscriber),
 		exit:        make(chan chan error),
-		wg:          wait(options.Context),
 	}
 
 	// configure the grpc server
@@ -128,6 +127,8 @@ func (g *grpcServer) configure(opts ...server.Option) {
 	for _, o := range opts {
 		o(&g.opts)
 	}
+
+	g.wg = wait(g.opts.Context)
 
 	g.rsvc = nil
 


### PR DESCRIPTION
I just found out that graceful shutdown is not working in grpc server plugin.

I expect server.Wait option to create internal wg to wait for all requests to be handled when kubernetes terminates pods.

But WaitGroup is only initiated in constructor and there's no way to reconfigure it.

This is how I turn on graceful shutdown:
```golang
service := micro.NewService(
  micro.Name("greeter"),
)
service.Init()

var wg sync.WaitGroup
srv := service.Server()

if err := srv.Init(server.Wait(&wg)); err != nil {
  log.Fatal("failed to init micro server", zap.Error(err))
}

```