### PR TITLE
Error while try get configure from remote nats. 

### DIFF
--- a/v4/config/source/nats/options.go
+++ b/v4/config/source/nats/options.go
@@ -15,17 +15,7 @@ type (
 )
 
 // WithUrl sets the nats url.
-func WithUrl(a string) source.Option {
-	return func(o *source.Options) {
-		if o.Context == nil {
-			o.Context = context.Background()
-		}
-		o.Context = context.WithValue(o.Context, urlKey{}, []string{a})
-	}
-}
-
-// WithUrls sets the nats multiple urls
-func WithUrls(a []string) source.Option {
+func WithUrl(a ...string) source.Option {
 	return func(o *source.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()

--- a/v4/config/source/nats/options.go
+++ b/v4/config/source/nats/options.go
@@ -20,6 +20,16 @@ func WithUrl(a string) source.Option {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
+		o.Context = context.WithValue(o.Context, urlKey{}, []string{a})
+	}
+}
+
+// WithUrls sets the nats multiple urls
+func WithUrls(a []string) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
 		o.Context = context.WithValue(o.Context, urlKey{}, a)
 	}
 }


### PR DESCRIPTION
fix(config/source/nats): urlKey{} option assuming multiple urls, but method nats.WithUrl put single url in context. Added wrapped array for method WithUrl , add new method WithUrls for multiple urls.