### PR TITLE
feat(logger/zap): direct use of zap.Logger

### DIFF
--- a/v4/logger/zap/options.go
+++ b/v4/logger/zap/options.go
@@ -36,3 +36,10 @@ type optionsKey struct{}
 func WithOptions(opts ...zap.Option) logger.Option {
 	return logger.SetOption(optionsKey{}, opts)
 }
+
+type loggerKey struct{}
+
+// WithLogger pass zap.Logger to logger
+func WithLogger(zapLogger *zap.Logger) logger.Option {
+	return logger.SetOption(loggerKey{}, zapLogger)
+}

--- a/v4/logger/zap/zap.go
+++ b/v4/logger/zap/zap.go
@@ -66,10 +66,17 @@ func (l *zaplog) Init(opts ...logger.Option) error {
 		log = log.WithOptions(options...)
 	}
 
+	// Using zap.Logger instance to replace internal logger
+	if zapLogger, ok := l.opts.Context.Value(loggerKey{}).(*zap.Logger); ok && zapLogger != nil {
+		l.zap = zapLogger
+	}
+
 	// defer log.Sync() ??
 
 	l.cfg = zapConfig
-	l.zap = log
+	if l.zap == nil {
+		l.zap = log
+	}
 	l.fields = make(map[string]interface{})
 
 	return nil

--- a/v4/logger/zap/zap_test.go
+++ b/v4/logger/zap/zap_test.go
@@ -1,6 +1,9 @@
 package zap
 
 import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"os"
 	"testing"
 
 	"go-micro.dev/v4/logger"
@@ -43,4 +46,19 @@ func TestSetLevel(t *testing.T) {
 
 	logger.Init(logger.WithLevel(logger.InfoLevel))
 	l.Logf(logger.DebugLevel, "test non-show debug: %s", "debug msg")
+}
+
+func TestZapLogger(t *testing.T) {
+	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	w := zapcore.AddSync(os.Stdout)
+	core := zapcore.NewCore(enc, w, zapcore.ErrorLevel)
+	zapLogger := zap.New(core)
+	l, err := NewLogger(logger.WithLevel(logger.InfoLevel), WithLogger(zapLogger))
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.Logf(logger.InfoLevel, "test non-show info: %s", "info msg")
+	l.Logf(logger.ErrorLevel, "test show error: %s", "error msg")
+	logger.Init(logger.WithLevel(logger.InfoLevel))
+	l.Logf(logger.InfoLevel, "test non-show info: %s", "info msg")
 }


### PR DESCRIPTION
In my use case, I already has a `zap.logger` instance, and I want to reuse it in go-micro logger. So I add an option to use the `zap.Logger` directly.