### PR TITLE
use redis SCAN

### DIFF
--- a/v4/store/redis/redis.go
+++ b/v4/store/redis/redis.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 
 	"github.com/go-redis/redis/v8"
-	log "go-micro.dev/v4/logger"
+	"go-micro.dev/v4/logger"
 	"go-micro.dev/v4/store"
 	"go-micro.dev/v4/util/cmd"
+)
+
+// DefaultDatabase is the namespace that the store
+// will use if no namespace is provided.
+var (
+	DefaultDatabase = "micro"
+	DefaultTable    = "micro"
 )
 
 type rkv struct {
@@ -137,7 +144,12 @@ func (r *rkv) String() string {
 }
 
 func NewStore(opts ...store.Option) store.Store {
-	var options store.Options
+	options := store.Options{
+		Database: DefaultDatabase,
+		Table:    DefaultTable,
+		Logger:   logger.DefaultLogger,
+	}
+
 	for _, o := range opts {
 		o(&options)
 	}
@@ -148,7 +160,7 @@ func NewStore(opts ...store.Option) store.Store {
 	}
 
 	if err := s.configure(); err != nil {
-		log.Fatal(err)
+		s.options.Logger.Log(logger.ErrorLevel, "Error configuring store ", err)
 	}
 
 	return s

--- a/v4/store/redis/redis_test.go
+++ b/v4/store/redis/redis_test.go
@@ -179,16 +179,12 @@ func Test_Store(t *testing.T) {
 	if tr := os.Getenv("TRAVIS"); len(tr) > 0 {
 		t.Skip()
 	}
-	r := new(rkv)
 
-	// r.options = store.Options{Nodes: []string{"redis://:password@127.0.0.1:6379"}}
-	//r.options = store.Options{Nodes: []string{"127.0.0.1:6379"}}
-	r.options = store.Options{Nodes: []string{"redis://127.0.0.1:6379"}}
-
-	if err := r.configure(); err != nil {
-		t.Error(err)
-		return
-	}
+	r := NewStore(
+		//store.Nodes("redis://:password@127.0.0.1:6379"),
+		//store.Nodes("127.0.0.1:6379"),
+		store.Nodes("redis://127.0.0.1:6379"),
+	)
 
 	key := "myTest"
 	rec := store.Record{

--- a/v4/store/redis/redis_test.go
+++ b/v4/store/redis/redis_test.go
@@ -197,19 +197,30 @@ func Test_Store(t *testing.T) {
 	if err != nil {
 		t.Errorf("Write Erroe. Error: %v", err)
 	}
+
 	rec1, err := r.Read(key)
 	if err != nil {
 		t.Errorf("Read Error. Error: %v\n", err)
 	}
-	err = r.Delete(rec1[0].Key)
-	if err != nil {
-		t.Errorf("Delete error %v\n", err)
-	}
+
 	keys, err := r.List()
 	if err != nil {
 		t.Errorf("listing error %v\n", err)
 	}
 	if len(keys) < 1 {
 		t.Errorf("not enough keys\n")
+	}
+
+	err = r.Delete(rec1[0].Key)
+	if err != nil {
+		t.Errorf("Delete error %v\n", err)
+	}
+
+	keys, err = r.List()
+	if err != nil {
+		t.Errorf("listing error %v\n", err)
+	}
+	if len(keys) > 0 {
+		t.Errorf("too many keys\n")
 	}
 }

--- a/v4/store/redis/redis_test.go
+++ b/v4/store/redis/redis_test.go
@@ -205,8 +205,11 @@ func Test_Store(t *testing.T) {
 	if err != nil {
 		t.Errorf("Delete error %v\n", err)
 	}
-	_, err = r.List()
+	keys, err := r.List()
 	if err != nil {
 		t.Errorf("listing error %v\n", err)
+	}
+	if len(keys) < 1 {
+		t.Errorf("not enough keys\n")
 	}
 }


### PR DESCRIPTION
redis KEYS may block other requests. This PR changes List and Read to SCAN and implements prefix and suffix

- do not fail when redis cannot be initialized
- make redis store use SCAN to list keys, with prefix and suffix
- read using SCAN with prefix and suffix
