### PR TITLE
fix(client/grpc): Removes the `connection` header

### DIFF
--- a/v4/client/grpc/grpc.go
+++ b/v4/client/grpc/grpc.go
@@ -205,6 +205,11 @@ func (g *grpcClient) stream(ctx context.Context, node *registry.Node, req client
 	header["x-content-type"] = req.ContentType()
 
 	md := gmetadata.New(header)
+
+	// WebSocket connection adds the `Connection: Upgrade` header.
+	// But as per the HTTP/2 spec, the `Connection` header makes the request malformed
+	delete(md, "connection")
+
 	ctx = gmetadata.NewOutgoingContext(ctx, md)
 
 	cf, err := g.newGRPCCodec(req.ContentType())


### PR DESCRIPTION
The HTTP/2 spec consider the request malformed
This header may have been added from a WebSocket connection