### PR TITLE
handle redis.Nil error properly

### DIFF
--- a/v4/store/redis/redis.go
+++ b/v4/store/redis/redis.go
@@ -3,6 +3,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -113,6 +114,9 @@ func (r *rkv) Read(key string, opts ...store.ReadOption) ([]*store.Record, error
 	}
 
 	if len(keys) == 1 {
+		if errors.Is(err, redis.Nil) {
+			return records, store.ErrNotFound
+		}
 		return records, err
 	}
 


### PR DESCRIPTION
This PR reintroduces mapping the `redis.Nil` error to `store.ErrNotFound` 