### PR TITLE
redis: Fix List call to strip table prefix from result

### DIFF
--- a/v4/store/redis/redis.go
+++ b/v4/store/redis/redis.go
@@ -4,6 +4,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -173,6 +174,10 @@ func (r *rkv) List(opts ...store.ListOption) ([]string, error) {
 		keys, cursor, err = r.Client.Scan(r.ctx, cursor, key, count).Result()
 		if err != nil {
 			return nil, err
+		}
+
+		for i, key := range keys {
+			keys[i] = strings.TrimPrefix(key, options.Table)
 		}
 
 		allKeys = append(allKeys, keys...)


### PR DESCRIPTION
The plugin stores the keys prefixed with the "Table" name in Redis. We should remove that prefix from the keys returned by "List()".

Partial-Fix: #57