### PR TITLE
only close channel once

### DIFF
--- a/v4/registry/kubernetes/watcher.go
+++ b/v4/registry/kubernetes/watcher.go
@@ -24,6 +24,7 @@ type k8sWatcher struct {
 
 	sync.RWMutex
 	pods map[string]*client.Pod
+	sync.Once
 }
 
 // build a cache of pods when the watcher starts.
@@ -164,7 +165,9 @@ func (k *k8sWatcher) Stop() {
 	case <-k.next:
 		return
 	default:
-		close(k.next)
+		k.Do(func() {
+			close(k.next)
+		})
 	}
 }
 


### PR DESCRIPTION
with https://github.com/go-micro/plugins/pull/113 we sometines see a panic like this:
```
panic: close of closed channel

goroutine 21629 [running]:
github.com/go-micro/plugins/v4/registry/kubernetes.(*k8sWatcher).Stop(0xc003e2f880)
    github.com/go-micro/plugins/v4/registry/kubernetes@v1.1.1/watcher.go:167 +0x56
go-micro.dev/v4/registry/cache.(*cache).watch.func1()
    go-micro.dev/v4@v4.9.0/registry/cache/cache.go:409 +0xe9
created by go-micro.dev/v4/registry/cache.(*cache).watch
    go-micro.dev/v4@v4.9.0/registry/cache/cache.go:403 +0xb8
```

I'm not proud of this solution and I tried using a Context and ContextCancel function as in the bodyWatcher, but that caused more problems than it solved. Any pointers on how to tackle this properly are welcome.