### PR TITLE
Allow synchronous publishing in Nats

### DIFF
--- a/v4/events/natsjs/nats.go
+++ b/v4/events/natsjs/nats.go
@@ -112,6 +112,16 @@ func (s *stream) Publish(topic string, msg interface{}, opts ...events.PublishOp
 	}
 
 	// publish the event to the topic's channel
+	// publish synchronously if configured
+	if s.opts.SyncPublish {
+		_, err := s.natsJetStreamCtx.Publish(event.Topic, bytes)
+		if err != nil {
+			err = errors.Wrap(err, "Error publishing message to topic")
+		}
+		return err
+	}
+
+	// publish asynchronously by default
 	if _, err := s.natsJetStreamCtx.PublishAsync(event.Topic, bytes); err != nil {
 		return errors.Wrap(err, "Error publishing message to topic")
 	}

--- a/v4/events/natsjs/options.go
+++ b/v4/events/natsjs/options.go
@@ -8,11 +8,12 @@ import (
 
 // Options which are used to configure the nats stream.
 type Options struct {
-	ClusterID string
-	ClientID  string
-	Address   string
-	TLSConfig *tls.Config
-	Logger    logger.Logger
+	ClusterID   string
+	ClientID    string
+	Address     string
+	TLSConfig   *tls.Config
+	Logger      logger.Logger
+	SyncPublish bool
 }
 
 // Option is a function which configures options.
@@ -50,5 +51,12 @@ func TLSConfig(t *tls.Config) Option {
 func Logger(log logger.Logger) Option {
 	return func(o *Options) {
 		o.Logger = log
+	}
+}
+
+// SynchronousPublish allows using a synchronous publishing instead of the default asynchronous
+func SynchronousPublish(sync bool) Option {
+	return func(o *Options) {
+		o.SyncPublish = sync
 	}
 }


### PR DESCRIPTION
We ran into problems when the nats server is crashing. Clients would keep the events in their queue waiting for nats to come up again. (This is the point in async publishing.) However if the clients get restarted while nats is gone the events will be lost and there is no way to retrieve them. 

This adds a configuration option to do synchronous publishes instead. The default is still asynchronous so there are no breaking changes. 
