### PR TITLE
Nats registry action

### DIFF
--- a/v4/registry/nats/options.go
+++ b/v4/registry/nats/options.go
@@ -11,6 +11,7 @@ type contextQuorumKey struct{}
 type optionsKey struct{}
 type watchTopicKey struct{}
 type queryTopicKey struct{}
+type registerActionKey struct{}
 
 var (
 	DefaultQuorum = 0
@@ -68,5 +69,19 @@ func WatchTopic(s string) registry.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, watchTopicKey{}, s)
+	}
+}
+
+// RegisterAction allows to set the action to use when registering to nats.
+// As of now there are three different options:
+// - "create" (default) only registers if there is noone already registered under the same key.
+// - "update" only updates the registration if it already exists.
+// - "put" creates or updates a registration
+func RegisterAction(s string) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, registerActionKey{}, s)
 	}
 }


### PR DESCRIPTION
We are using nats as service registry. When a service is restarting it wouldn't update the registry entry. Looking into it, this was because the nats registry only does a `"create"` action when storing to nats. That means that existing entries are not overwritten.

Since it looked like it was a deliberate decision to use `"create"`, this adds a configuration option `RegisterAction` for it. It can be used with `"put"` to update *or* create a new registry entry. It could also be used with `"update"` if one doesn't want to create new registry entries if they do not exist.

The default is still `"create"` so there are no breaking changes.