### PR TITLE
Allow naming nats connections

### DIFF
--- a/v4/events/natsjs/nats.go
+++ b/v4/events/natsjs/nats.go
@@ -56,6 +56,9 @@ func connectToNatsJetStream(options Options) (nats.JetStreamContext, error) {
 		nopts.Servers = strings.Split(options.Address, ",")
 	}
 
+	if options.Name != "" {
+		nopts.Name = options.Name
+	}
 	conn, err := nopts.Connect()
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to nats at %v with tls enabled (%v): %v", options.Address, nopts.TLSConfig != nil, err)

--- a/v4/events/natsjs/options.go
+++ b/v4/events/natsjs/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	TLSConfig   *tls.Config
 	Logger      logger.Logger
 	SyncPublish bool
+	Name        string
 }
 
 // Option is a function which configures options.
@@ -58,5 +59,12 @@ func Logger(log logger.Logger) Option {
 func SynchronousPublish(sync bool) Option {
 	return func(o *Options) {
 		o.SyncPublish = sync
+	}
+}
+
+// Name allows to add a name to the natsjs connection
+func Name(name string) Option {
+	return func(o *Options) {
+		o.Name = name
 	}
 }


### PR DESCRIPTION
Allow to set names for the nats connections. In big deployments it can be cumbersome to keep track of nats connections otherwise
