### PR TITLE
feat: add rabbitmq.PublishDeliveryMode, a client.PublishOption for setting message delivery mode

### DIFF
--- a/v4/broker/rabbitmq/options.go
+++ b/v4/broker/rabbitmq/options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go-micro.dev/v4/broker"
+	"go-micro.dev/v4/client"
 )
 
 type durableQueueKey struct{}
@@ -163,4 +164,15 @@ type ackSuccessKey struct{}
 // AckOnSuccess will automatically acknowledge messages when no error is returned.
 func AckOnSuccess() broker.SubscribeOption {
 	return setSubscribeOption(ackSuccessKey{}, true)
+}
+
+// PublishDeliveryMode client.PublishOption for setting message "delivery mode"
+// mode , Transient (0 or 1) or Persistent (2)
+func PublishDeliveryMode(mode uint8) client.PublishOption {
+	return func(o *client.PublishOptions) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, deliveryMode{}, mode)
+	}
 }


### PR DESCRIPTION
`Event.Publish` accept client.PublishOption, so I add a new  client.PublishOption to set message delivery mode.

It has the same functionality with `rabbitmq.DeliveryMode()`, but as a `client.PublishOption`

```go
// Event is used to publish messages to a topic.
type Event interface {
  // Publish publishes a message to the event topic
  Publish(ctx context.Context, msg interface{}, opts ...client.PublishOption) error
}
```


usage:

```go
...

publisher := micro.NewEvent(topic, microClient).
opt := rabbitmq.PublishDeliveryMode(2)

publisher.Publish(ctx, msg, opt)

...
```