### PR TITLE
fix: ttl bug in case re-lock

### DIFF
--- a/v4/sync/memory/memory.go
+++ b/v4/sync/memory/memory.go
@@ -118,7 +118,7 @@ func (m *memorySync) Lock(id string, opts ...sync.LockOption) error {
 			// release the lock if it expired
 			_ = m.Unlock(id)
 		} else {
-			ttl = time.After(live)
+			ttl = time.After(lk.ttl - live)
 		}
 	}
 


### PR DESCRIPTION
There seems to be a typo here.

----
Simple showcase:

```go
  m := memory.NewSync()
  
  // success immediately
  _ = m.Lock("test", sync.LockTTL(time.Hour))
  
  // **Should block and wait**, but it also succeeds immediately, which is incorrect
  _ = m.Lock("test", sync.LockTTL(time.Hour))

```
