### PR TITLE
added support passing exchange type when declaring durable exchange

### DIFF
--- a/v4/broker/rabbitmq/channel.go
+++ b/v4/broker/rabbitmq/channel.go
@@ -107,15 +107,15 @@ func (r *rabbitMQChannel) DeclareExchange(ex Exchange) error {
 	)
 }
 
-func (r *rabbitMQChannel) DeclareDurableExchange(exchange string) error {
+func (r *rabbitMQChannel) DeclareDurableExchange(ex Exchange) error {
 	return r.channel.ExchangeDeclare(
-		exchange, // name
-		"topic",  // kind
-		true,     // durable
-		false,    // autoDelete
-		false,    // internal
-		false,    // noWait
-		nil,      // args
+		ex.Name,         // name
+		string(ex.Type), // kind
+		true,            // durable
+		false,           // autoDelete
+		false,           // internal
+		false,           // noWait
+		nil,             // args
 	)
 }
 

--- a/v4/broker/rabbitmq/connection.go
+++ b/v4/broker/rabbitmq/connection.go
@@ -252,7 +252,7 @@ func (r *rabbitMQConn) tryConnect(secure bool, config *amqp.Config) error {
 
 	if !r.withoutExchange {
 		if r.exchange.Durable {
-			r.Channel.DeclareDurableExchange(r.exchange.Name)
+			r.Channel.DeclareDurableExchange(r.exchange)
 		} else {
 			r.Channel.DeclareExchange(r.exchange)
 		}


### PR DESCRIPTION
While working with the rabbitmq plugin, I encountered the problem that exchange, which is declared with the "fanout" type, is displayed as "topic" in the admin panel. While examining the plugin code, I discovered that when the DeclareDurableExchange function is called, the exchange type is always set to “topic”. I'm guessing this is a mistake. I have made corrections, please consider the request.