### PR TITLE
Allow username/password authentication in events/natsjs

### DIFF
--- a/v4/events/natsjs/nats.go
+++ b/v4/events/natsjs/nats.go
@@ -69,6 +69,11 @@ func connectToNatsJetStream(options Options) (nats.JetStreamContext, error) {
 		nopts.Name = options.Name
 	}
 
+	if options.Username != "" && options.Password != "" {
+		nopts.User = options.Username
+		nopts.Password = options.Password
+	}
+
 	conn, err := nopts.Connect()
 	if err != nil {
 		tls := nopts.TLSConfig != nil

--- a/v4/events/natsjs/options.go
+++ b/v4/events/natsjs/options.go
@@ -17,6 +17,8 @@ type Options struct {
 	SyncPublish           bool
 	Name                  string
 	DisableDurableStreams bool
+	Username              string
+	Password              string
 }
 
 // Option is a function which configures options.
@@ -82,5 +84,13 @@ func Name(name string) Option {
 func DisableDurableStreams() Option {
 	return func(o *Options) {
 		o.DisableDurableStreams = true
+	}
+}
+
+// Authenticate authenticates the connection with the given username and password.
+func Authenticate(username, password string) Option {
+	return func(o *Options) {
+		o.Username = username
+		o.Password = password
 	}
 }


### PR DESCRIPTION
Adds an option to authenticate via username/password to the `events/natsjs` implementation
