### PR TITLE
server/grpc: add configurable graceful shutdown timeout (v4 & v5)

### DIFF
--- a/v4/server/grpc/grpc.go
+++ b/v4/server/grpc/grpc.go
@@ -983,9 +983,14 @@ func (g *grpcServer) Start() error {
 			close(exit)
 		}()
 
+		gracefulTimeout := time.Second
+		if v, ok := g.opts.Context.Value(gracefulStopTimeoutKey{}).(time.Duration); ok && v > 0 {
+			gracefulTimeout = v
+		}
+
 		select {
 		case <-exit:
-		case <-time.After(time.Second):
+		case <-time.After(gracefulTimeout):
 			g.srv.Stop()
 		}
 

--- a/v4/server/grpc/options.go
+++ b/v4/server/grpc/options.go
@@ -74,9 +74,8 @@ func MaxMsgSize(s int) server.Option {
 	return setServerOption(maxMsgSizeKey{}, s)
 }
 
-// GracefulStopTimeout sets the maximum duration the server will wait for
-// in-flight requests to complete during graceful shutdown before forcefully
-// stopping. Default is 1 second.
+// GracefulStopTimeout set the timeout for the server to stop gracefully
+// before forcefully stopping.  Default is 1 second.
 func GracefulStopTimeout(d time.Duration) server.Option {
 	return setServerOption(gracefulStopTimeoutKey{}, d)
 }

--- a/v4/server/grpc/options.go
+++ b/v4/server/grpc/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"time"
 
 	"go-micro.dev/v4/broker"
 	"go-micro.dev/v4/codec"
@@ -22,6 +23,7 @@ type maxMsgSizeKey struct{}
 type maxConnKey struct{}
 type tlsAuth struct{}
 type grpcServerKey struct{}
+type gracefulStopTimeoutKey struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type.
 func Codec(contentType string, c encoding.Codec) server.Option {
@@ -70,6 +72,13 @@ func Options(opts ...grpc.ServerOption) server.Option {
 // send.  Default maximum message size is 4 MB.
 func MaxMsgSize(s int) server.Option {
 	return setServerOption(maxMsgSizeKey{}, s)
+}
+
+// GracefulStopTimeout sets the maximum duration the server will wait for
+// in-flight requests to complete during graceful shutdown before forcefully
+// stopping. Default is 1 second.
+func GracefulStopTimeout(d time.Duration) server.Option {
+	return setServerOption(gracefulStopTimeoutKey{}, d)
 }
 
 func newOptions(opt ...server.Option) server.Options {

--- a/v5/server/grpc/grpc.go
+++ b/v5/server/grpc/grpc.go
@@ -983,9 +983,14 @@ func (g *grpcServer) Start() error {
 			close(exit)
 		}()
 
+		gracefulTimeout := time.Second
+		if v, ok := g.opts.Context.Value(gracefulStopTimeoutKey{}).(time.Duration); ok && v > 0 {
+			gracefulTimeout = v
+		}
+
 		select {
 		case <-exit:
-		case <-time.After(time.Second):
+		case <-time.After(gracefulTimeout):
 			g.srv.Stop()
 		}
 

--- a/v5/server/grpc/options.go
+++ b/v5/server/grpc/options.go
@@ -74,9 +74,8 @@ func MaxMsgSize(s int) server.Option {
 	return setServerOption(maxMsgSizeKey{}, s)
 }
 
-// GracefulStopTimeout sets the maximum duration the server will wait for
-// in-flight requests to complete during graceful shutdown before forcefully
-// stopping. Default is 1 second.
+// GracefulStopTimeout set the timeout for the server to stop gracefully
+// before forcefully stopping.  Default is 1 second.
 func GracefulStopTimeout(d time.Duration) server.Option {
 	return setServerOption(gracefulStopTimeoutKey{}, d)
 }

--- a/v5/server/grpc/options.go
+++ b/v5/server/grpc/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"time"
 
 	"go-micro.dev/v5/broker"
 	"go-micro.dev/v5/codec"
@@ -22,6 +23,7 @@ type maxMsgSizeKey struct{}
 type maxConnKey struct{}
 type tlsAuth struct{}
 type grpcServerKey struct{}
+type gracefulStopTimeoutKey struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type.
 func Codec(contentType string, c encoding.Codec) server.Option {
@@ -70,6 +72,13 @@ func Options(opts ...grpc.ServerOption) server.Option {
 // send.  Default maximum message size is 4 MB.
 func MaxMsgSize(s int) server.Option {
 	return setServerOption(maxMsgSizeKey{}, s)
+}
+
+// GracefulStopTimeout sets the maximum duration the server will wait for
+// in-flight requests to complete during graceful shutdown before forcefully
+// stopping. Default is 1 second.
+func GracefulStopTimeout(d time.Duration) server.Option {
+	return setServerOption(gracefulStopTimeoutKey{}, d)
 }
 
 func newOptions(opt ...server.Option) server.Options {


### PR DESCRIPTION
## Summary

- Add `GracefulStopTimeout` server option to configure how long the gRPC server waits for in-flight requests to complete during graceful shutdown
- Applied to both v4 and v5 plugins
- Defaults to `time.Second` for backwards compatibility

## Problem

The gRPC server has a hardcoded 1-second timeout after calling `GracefulStop()` before forcefully calling `Stop()`. For applications with long-lived gRPC streams (e.g., server-side streaming in Kubernetes), this causes active streams to be terminated with `ECONNRESET` during rolling updates, even when `terminationGracePeriodSeconds` allows for graceful draining.

## Usage

```go
import (
    grpcsrv "github.com/go-micro/plugins/v4/server/grpc"
)

srv := micro.NewService(
    micro.Server(grpcsrv.NewServer(
        grpcsrv.GracefulStopTimeout(3 * time.Minute),
    )),
)
```

## Changes

- `v4/server/grpc/options.go` — add `GracefulStopTimeout` option and context key
- `v4/server/grpc/grpc.go` — read option, fall back to `time.Second`
- `v5/server/grpc/options.go` — same
- `v5/server/grpc/grpc.go` — same

Fixes #162